### PR TITLE
Update devDependencies and travis CI support node versions

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "excludeFiles": ["node_modules/**", "coverage/**", "tmp/**"],
-  "preset": "hexo"
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ node_js:
 
 script:
   - npm run eslint
-  - npm run jscs
   - npm run test-cov
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ cache:
     - node_modules
 
 node_js:
-  - "0.12"
-  - "4"
   - "6"
+  - "8"
+  - "node"
 
 script:
   - npm run eslint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/front_matter",
   "scripts": {
     "eslint": "eslint .",
-    "jscs": "jscs .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -27,13 +26,11 @@
     "js-yaml": "^3.6.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
-    "eslint": "^2.12.0",
-    "eslint-config-hexo": "^1.0.3",
-    "istanbul": "^0.4.3",
-    "jscs": "^3.0.4",
-    "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^2.5.3",
-    "moment": "^2.13.0"
+    "chai": "^4.2.0",
+    "eslint": "^5.6.1",
+    "eslint-config-hexo": "^3.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.2.0",
+    "moment": "^2.22.2"
   }
 }


### PR DESCRIPTION
* Update devDependencies
* Update travis CI supports node version (drop 0.12, 4 and support  8, latest LTS)

Sorry, TravisCI has some errors related with node and eslint version, but I'm going to fix these errors next PR if merge this.