### PR TITLE
Update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "js-yaml": "^3.6.1"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.2.0",
     "eslint": "^2.12.0",
     "eslint-config-hexo": "^1.0.3",
-    "istanbul": "^0.4.3",
+    "istanbul": "^0.4.5",
     "jscs": "^3.0.4",
     "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^2.5.3",
-    "moment": "^2.13.0"
+    "mocha": "^5.2.0",
+    "moment": "^2.22.2"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
This PR update devDependencies except eslint & jscs.

A eslint command apper many error, after version up eslint and related package.
And jscs package can drop, if version up eslint.

So, I think these change (version up eslint & drop jscs) do as same commit is better.
I will be update eslint & drop jscs next PR, if this PR is merged.