### PR TITLE
Use eslint instead of jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "excludeFiles": ["node_modules/**", "coverage/**", "tmp/**"],
-  "preset": "hexo"
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ node_js:
 
 script:
   - npm run eslint
-  - npm run jscs
   - npm run test-cov
 
 after_script:

--- a/lib/front_matter.js
+++ b/lib/front_matter.js
@@ -58,7 +58,7 @@ function parse(str, options) {
 
   const keys = Object.keys(data);
   let key = '';
-  let item;
+  let item = '';
 
   // Convert timezone
   for (let i = 0, len = keys.length; i < len; i++) {
@@ -66,7 +66,7 @@ function parse(str, options) {
     item = data[key];
 
     if (item instanceof Date) {
-      data[key] = new Date(item.getTime() + item.getTimezoneOffset() * 60 * 1000);
+      data[key] = new Date(item.getTime() + (item.getTimezoneOffset() * 60 * 1000));
     }
   }
 
@@ -85,7 +85,7 @@ function parseJSON(str) {
   try {
     return JSON.parse(`{${str}}`);
   } catch (err) {
-    return;
+    return; // eslint-disable-line
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/front_matter",
   "scripts": {
     "eslint": "eslint .",
-    "jscs": "jscs .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js"
   },
@@ -28,11 +27,9 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^2.12.0",
-    "eslint-config-hexo": "^1.0.3",
+    "eslint": "^5.7.0",
+    "eslint-config-hexo": "^3.0.0",
     "istanbul": "^0.4.5",
-    "jscs": "^3.0.4",
-    "jscs-preset-hexo": "^1.0.1",
     "mocha": "^5.2.0",
     "moment": "^2.22.2"
   },


### PR DESCRIPTION
Update devDependencies and delete jscs.
[jscs has already merged with eslint](https://www.npmjs.com/package/jscs). This PR update eslint and it version include merged jscs.

And I some fix of eslint error after update it.