### PR TITLE
chore: specify files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.idea/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "lib/"
+  ],
   "repository": "hexojs/hexo-front-matter",
   "keywords": [
     "front-matter",


### PR DESCRIPTION
deprecate npmignore