### PR TITLE
2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-front-matter",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Front-matter parser.",
   "main": "lib/front_matter",
   "scripts": {
@@ -37,6 +37,6 @@
     "nyc": "^15.0.0"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.13.0"
   }
 }


### PR DESCRIPTION
Release 2.0.0.

A major version bump due to minimum required nodejs version change & #24, which changes the way of exports.

Waiting for #34