### PR TITLE
chore: update `package.json` for release typescript package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "lib": "./lib"
   },
   "files": [
-    "lib/"
+    "dist/**"
   ],
+  "types": "./dist/front_matter.d.ts",
   "repository": "hexojs/hexo-front-matter",
   "keywords": [
     "front-matter",


### PR DESCRIPTION
Follow up #59 

## Before fix

```sh
$ npm publish --dry-run
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm notice 
npm notice 📦  hexo-front-matter@4.0.0
npm notice === Tarball Contents ===
npm notice 1.3kB README.md
npm notice 4.1kB lib/front_matter.ts
npm notice 1.2kB package.json
npm notice === Tarball Details ===
npm notice name:          hexo-front-matter
npm notice version:       4.0.0
npm notice filename:      hexo-front-matter-4.0.0.tgz
npm notice package size:  2.5 kB
npm notice unpacked size: 6.6 kB
npm notice shasum:        91a69c90ac02748ff0d6d149600a4fbbd2f8fb11
npm notice integrity:     sha512-034a5qZfapbb6[...]L0LFEHcK4saow==
npm notice total files:   3
npm notice
+ hexo-front-matter@4.0.0
```

## After fix

```sh
$ npm publish --dry-run
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
npm notice 
npm notice 📦  hexo-front-matter@4.0.0
npm notice === Tarball Contents ===
npm notice 1.3kB README.md
npm notice 581B  dist/front_matter.d.ts
npm notice 4.9kB dist/front_matter.js
npm notice 5.1kB dist/front_matter.js.map
npm notice 1.3kB package.json
npm notice === Tarball Details ===
npm notice name:          hexo-front-matter
npm notice version:       4.0.0
npm notice filename:      hexo-front-matter-4.0.0.tgz
npm notice package size:  4.0 kB
npm notice unpacked size: 13.3 kB
npm notice shasum:        1aebec67db38fc16975218438a3efaf85b0c6d14
npm notice integrity:     sha512-yhDe6ScwmKLgl[...]CLRaHtbI5OTIQ==
npm notice total files:   5
npm notice
+ hexo-front-matter@4.0.0

```