### PR TITLE
fix: make parse options optional

### DIFF
--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,7 +32,7 @@ function split(str: string) {
   return { content: str };
 }
 
-function parse(str: string, options: yaml.LoadOptions) {
+function parse(str: string, options?: yaml.LoadOptions) {
   if (typeof str !== 'string') throw new TypeError('str is required!');
 
   const splitData = split(str);


### PR DESCRIPTION
The only usage of `options` is in line 67 `yaml.load()`, whose `options` can be an optional argument.

Make `options` optional can allow calling `parse` function with `parse(str)`, instead of having to add an empty object `parse(str, {})`.