### PR TITLE
fix: date localestring format error

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -339,19 +339,11 @@ describe('Front-matter', () => {
 
     // Date parsing bug (issue #1)
     it('date', () => {
-      const unixTime = Date.now();
-      const stringifyDateTime = new Date(unixTime)
-        .toLocaleString(
-          'en-CA', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            hour12: false,
-            minute: '2-digit',
-            second: '2-digit'
-          }
-        ).replace(/,/g, '');
+      const current = new Date();
+      const unixTime = current.getTime();
+      // js-yaml only accept ISO 8601 format date string as valid date type.
+      // Date.prototype.toJSON method automatically applied offset, so we need to revert that.
+      const stringifyDateTime = new Date(current.getTime() - (current.getTimezoneOffset() * 60 * 1000)).toJSON();
 
       const str = [
         `date: ${stringifyDateTime}`,
@@ -365,18 +357,7 @@ describe('Front-matter', () => {
 
   describe('stringify', () => {
     it('yaml', () => {
-      const now = new Date()
-        .toLocaleString(
-          'en-CA', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            hour12: false,
-            minute: '2-digit',
-            second: '2-digit'
-          }
-        ).replace(/,/g, '');
+      const now = new Date().toJSON();
 
       const data = {
         layout: 'post',


### PR DESCRIPTION
Since node v18.13.0, ICU is updated to 72.1, which changes the behavior of 'en-CA' toLocaleString.

- https://github.com/nodejs/node/issues/45945
- https://github.com/nodejs/node/releases/tag/v18.13.0

Its output could be formatted to `YYYY-MM-DD HH:mm:ss`, but now it becomes `MM/DD/YYYY HH:mm:ss`, which is no longer a valid ISO 8601 representation.

The `Date.prototype.toJSON` or `Date.prototype.toISOString` is guaranteed to produce ISO 8601 format string, so we can use these methods instead.
