### PR TITLE
some fixes as description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/
 coverage
 dist
 package-lock.json
+.vscode

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -55,7 +55,7 @@ function parse(str: string, options: yaml.LoadOptions = {}) {
   if (splitData.separator.startsWith(';')) {
     data = parseJSON(raw);
   } else {
-    data = <any>parseYAML(raw, options);
+    data = parseYAML(raw, options) as any;
   }
 
   if (!data) return { _content: str };

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,15 +32,16 @@ function split(str: string) {
   return { content: str };
 }
 
-export type ParseResult = Record<string, any> & Partial<{
-  _content: string;
-  title: string;
-  description: string;
-  thumbnail: string;
-  date: any;
-  updated: any;
-  permalink: string;
-}>
+export type ParseResult = Record<string, any> &
+	Partial<{
+		_content: string;
+		title: string;
+		description: string;
+		thumbnail: string;
+		date: any;
+		updated: any;
+		permalink: string;
+	}>;
 
 function parse(str: string, options: yaml.LoadOptions = {}) {
   if (typeof str !== 'string') throw new TypeError('str is required!');

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -111,7 +111,7 @@ interface Options {
 	separator?: string;
 }
 
-function stringify(obj: Record<string, any>, options: Options = {}) {
+function stringify(obj: Record<string, any>, options: Options = {}): string {
   if (!obj) throw new TypeError('obj is required!');
 
   const { _content: content = '' } = obj;

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,12 +1,9 @@
-'use strict';
-
 /**
  * @type {{ [key: string]: import("lint-staged").Commands | import("lint-staged").ConfigFn }}
  */
 const config = {
-  '*.ts': ['npx prettier --write', 'eslint --fix'],
-  '*.html': ['npx eslint --fix', 'prettier --write'],
-  '*.scss': 'npx prettier --write',
+  '*.ts': 'eslint --fix',
+  '*.js': 'eslint --fix',
   '*.json': 'npx prettier --write',
   '*.yml': 'npx prettier --write'
 };

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * @type {{ [key: string]: import("lint-staged").Commands | import("lint-staged").ConfigFn }}
+ */
+const config = {
+  '*.ts': ['npx prettier --write', 'eslint --fix'],
+  '*.html': ['npx eslint --fix', 'prettier --write'],
+  '*.scss': 'npx prettier --write',
+  '*.json': 'npx prettier --write',
+  '*.yml': 'npx prettier --write'
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "eslint": "eslint .",
     "pretest": "npm run clean && npm run build",
     "test": "mocha test/index.js --require ts-node/register",
-    "test-cov": "c8 --reporter=lcovonly npm run test"
+    "test-cov": "c8 --reporter=lcovonly npm run test",
+    "prepare": "husky install"
   },
   "files": [
     "dist"
@@ -39,6 +40,8 @@
     "chai": "^4.3.6",
     "eslint": "^8.23.1",
     "eslint-config-hexo": "^5.0.0",
+    "husky": "^8.0.3",
+    "lint-staged": "^13.2.2",
     "mocha": "^10.0.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.8.4"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,14 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "sourceMap": true,
-    "outDir": "dist",
-    "declaration": true,
-    "esModuleInterop": true,
-    "skipDefaultLibCheck": true,
-    "skipLibCheck": true
-  },
-  "include": [
-    "lib/front_matter.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		"module": "CommonJS",
+		"target": "ES6",
+		"sourceMap": true,
+		"outDir": "dist",
+		"declaration": true,
+		"esModuleInterop": true,
+		"skipDefaultLibCheck": true,
+		"skipLibCheck": true
+	},
+	"include": ["lib/front_matter.ts"],
+	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## fix: types node
install `@types/node` instead override `type: node`
- https://github.com/dimaslanjaka/hexo-front-matter/commit/68b5eef00b2c593378a7d7f4d8f0695b71726b2b
- https://github.com/dimaslanjaka/hexo-front-matter/commit/2f1c469a83c44c9cfd91d994d7c5644b428004b2

## feat: enable ESModule imports
- https://github.com/hexojs/hexo-front-matter/pull/70/commits/2f1c469a83c44c9cfd91d994d7c5644b428004b2#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0

## fix: failed build caused by missing lib
Skip type checking of declaration files from `node_modules`. This can save time during compilation at the expense of type-system accuracy
- https://github.com/dimaslanjaka/hexo-front-matter/commit/03fc40d272367f83ce9b0234288735c40a98739c

## chore: separate result type and make `options` as optional
separate result type
- https://github.com/hexojs/hexo-front-matter/commit/493fd35100f350d7239f8080ff698693863498a5
- https://github.com/hexojs/hexo-front-matter/commit/594844a55b7261244398648939a6e19102e64210
optional `options` by adding default options `empty object`
- https://github.com/dimaslanjaka/hexo-front-matter/blob/f15a9220ac1107bf287cb41c3fae51d895528d19/lib/front_matter.ts#L45

## refactor: implement `lint-staged` and `husky`
to automatically fix code style before commited
- https://github.com/dimaslanjaka/hexo-front-matter/commit/6ec68d7d737dd12f3441b7093af745e0b416677c
- https://github.com/dimaslanjaka/hexo-front-matter/commit/87dd66e6ce413194f04b7c4c1bd7b9a204a7ddbf

