### PR TITLE
chore: Separate result options & Improve TSConfig

### DIFF
--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -141,8 +141,8 @@ type YamlMergedOpts = Options & yaml.DumpOptions;
 function stringifyYAML(obj: Record<string, any>, options: YamlMergedOpts) {
   const keys = Object.keys(obj);
   const data = {};
-  const nullKeys = [];
-  const dateKeys = [];
+  const nullKeys: string[] = [];
+  const dateKeys: string[] = [];
   let key: string, value: any, i: number, len: number;
 
   for (i = 0, len = keys.length; i < len; i++) {

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,7 +32,18 @@ function split(str: string) {
   return { content: str };
 }
 
-function parse(str: string, options?: yaml.LoadOptions) {
+export type ParseResult = Record<string, any> &
+	Partial<{
+		_content: string;
+		title: string;
+		description: string;
+		thumbnail: string;
+		date: any;
+		updated: any;
+		permalink: string;
+	}>;
+
+function parse(str: string, options: yaml.LoadOptions = {}) {
   if (typeof str !== 'string') throw new TypeError('str is required!');
 
   const splitData = split(str);
@@ -45,7 +56,7 @@ function parse(str: string, options?: yaml.LoadOptions) {
   if (splitData.separator.startsWith(';')) {
     data = parseJSON(raw);
   } else {
-    data = <any>parseYAML(raw, options);
+    data = parseYAML(raw, options) as any;
   }
 
   if (!data) return { _content: str };
@@ -100,7 +111,7 @@ interface Options {
 	separator?: string;
 }
 
-function stringify(obj: Record<string, any>, options: Options = {}) {
+function stringify(obj: Record<string, any>, options: Options = {}): string {
   if (!obj) throw new TypeError('obj is required!');
 
   const { _content: content = '' } = obj;

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -40,12 +40,20 @@ function parse(str: string, options: yaml.LoadOptions = {}) {
 
   if (!raw) return { _content: str };
 
-  let data;
+  let data: Partial<{
+		[key: string]: any;
+		_content: string;
+		title: string;
+		description: string;
+		thumbnail: string;
+		date: any;
+		updated: any;
+	}>;
 
   if (splitData.separator.startsWith(';')) {
     data = parseJSON(raw);
   } else {
-    data = parseYAML(raw, options);
+    data = <any>parseYAML(raw, options);
   }
 
   if (!data) return { _content: str };
@@ -55,7 +63,9 @@ function parse(str: string, options: yaml.LoadOptions = {}) {
     const item = data[key];
 
     if (item instanceof Date) {
-      data[key] = new Date(item.getTime() + (item.getTimezoneOffset() * 60 * 1000));
+      data[key] = new Date(
+        item.getTime() + (item.getTimezoneOffset() * 60 * 1000)
+      );
     }
   });
 
@@ -63,18 +73,18 @@ function parse(str: string, options: yaml.LoadOptions = {}) {
   return data;
 }
 
-function parseYAML(str, options: yaml.LoadOptions) {
+function parseYAML(str: string, options: yaml.LoadOptions) {
   const result = yaml.load(escapeYAML(str), options);
   if (typeof result !== 'object') return;
 
   return result;
 }
 
-function parseJSON(str) {
+function parseJSON(str: string) {
   try {
     return JSON.parse(`{${str}}`);
   } catch (err) {
-    return; // eslint-disable-line
+		return; // eslint-disable-line
   }
 }
 
@@ -93,12 +103,12 @@ function escapeYAML(str: string) {
 }
 
 interface Options {
-  mode?: 'json' | '',
-  prefixSeparator?: boolean,
-  separator?: string
+	mode?: 'json' | '';
+	prefixSeparator?: boolean;
+	separator?: string;
 }
 
-function stringify(obj, options: Options = {}) {
+function stringify(obj: Record<string, any>, options: Options = {}) {
   if (!obj) throw new TypeError('obj is required!');
 
   const { _content: content = '' } = obj;
@@ -123,12 +133,14 @@ function stringify(obj, options: Options = {}) {
   return result;
 }
 
-function stringifyYAML(obj, options) {
+type YamlMergedOpts = Options & yaml.DumpOptions;
+
+function stringifyYAML(obj: Record<string, any>, options: YamlMergedOpts) {
   const keys = Object.keys(obj);
   const data = {};
   const nullKeys = [];
   const dateKeys = [];
-  let key, value, i, len;
+  let key: string, value: any, i: number, len: number;
 
   for (i = 0, len = keys.length; i < len; i++) {
     key = keys[i];
@@ -162,24 +174,25 @@ function stringifyYAML(obj, options) {
 }
 
 function stringifyJSON(obj) {
-  return JSON.stringify(obj, null, '  ')
+  return (
+    JSON.stringify(obj, null, '  ')
     // Remove indention
-    .replace(/\n {2}/g, () => '\n')
+      .replace(/\n {2}/g, () => '\n')
     // Remove prefixing and trailing braces
-    .replace(/^{\n|}$/g, '');
+      .replace(/^{\n|}$/g, '')
+  );
 }
 
-function doubleDigit(num) {
+function doubleDigit(num: number) {
   return num.toString().padStart(2, '0');
 }
 
-function formatDate(date) {
-  return `${date.getFullYear()}-${doubleDigit(date.getMonth() + 1)}-${doubleDigit(date.getDate())} ${doubleDigit(date.getHours())}:${doubleDigit(date.getMinutes())}:${doubleDigit(date.getSeconds())}`;
+function formatDate(date: Date) {
+  return `${date.getFullYear()}-${doubleDigit(
+    date.getMonth() + 1
+  )}-${doubleDigit(date.getDate())} ${doubleDigit(
+    date.getHours()
+  )}:${doubleDigit(date.getMinutes())}:${doubleDigit(date.getSeconds())}`;
 }
 
-export {
-  parse,
-  split,
-  escapeYAML as escape,
-  stringify
-};
+export { parse, split, escapeYAML as escape, stringify };

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -39,6 +39,7 @@ export type ParseResult = Record<string, any> & Partial<{
   thumbnail: string;
   date: any;
   updated: any;
+  permalink: string;
 }>
 
 function parse(str: string, options: yaml.LoadOptions = {}) {

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,7 +32,7 @@ function split(str: string) {
   return { content: str };
 }
 
-function parse(str: string, options: yaml.LoadOptions) {
+function parse(str: string, options?: yaml.LoadOptions) {
   if (typeof str !== 'string') throw new TypeError('str is required!');
 
   const splitData = split(str);

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,7 +32,7 @@ function split(str: string) {
   return { content: str };
 }
 
-function parse(str: string, options?: yaml.LoadOptions) {
+function parse(str: string, options: yaml.LoadOptions = {}) {
   if (typeof str !== 'string') throw new TypeError('str is required!');
 
   const splitData = split(str);

--- a/lib/front_matter.ts
+++ b/lib/front_matter.ts
@@ -32,6 +32,15 @@ function split(str: string) {
   return { content: str };
 }
 
+export type ParseResult = Record<string, any> & Partial<{
+  _content: string;
+  title: string;
+  description: string;
+  thumbnail: string;
+  date: any;
+  updated: any;
+}>
+
 function parse(str: string, options: yaml.LoadOptions = {}) {
   if (typeof str !== 'string') throw new TypeError('str is required!');
 
@@ -40,15 +49,7 @@ function parse(str: string, options: yaml.LoadOptions = {}) {
 
   if (!raw) return { _content: str };
 
-  let data: Partial<{
-		[key: string]: any;
-		_content: string;
-		title: string;
-		description: string;
-		thumbnail: string;
-		date: any;
-		updated: any;
-	}>;
+  let data: ParseResult;
 
   if (splitData.separator.startsWith(';')) {
     data = parseJSON(raw);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "hexo-front-matter",
   "version": "4.1.0",
   "description": "Front-matter parser.",
-  "main": "dist/front_matter",
+  "main": "dist/front_matter.js",
+  "types": "./dist/front_matter.d.ts",
   "scripts": {
     "prepublish ": "npm run clean && npm run build",
     "build": "tsc -b",
@@ -13,9 +14,8 @@
     "test-cov": "c8 --reporter=lcovonly npm run test"
   },
   "files": [
-    "dist/**"
+    "dist"
   ],
-  "types": "./dist/front_matter.d.ts",
   "repository": "hexojs/hexo-front-matter",
   "keywords": [
     "front-matter",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "^18.15.13",
+    "@types/node": "^18.16.3",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "c8": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "^18.11.7",
+    "@types/node": "^18.15.13",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "c8": "^7.12.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,14 @@
 {
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "sourceMap": true,
-    "outDir": "dist",
-    "declaration": true,
-    "esModuleInterop": true,
-    "skipDefaultLibCheck": true,
-    "skipLibCheck": true
-  },
-  "include": [
-    "lib/front_matter.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+	"compilerOptions": {
+		"module": "CommonJS",
+		"target": "ES6",
+		"sourceMap": true,
+		"outDir": "dist",
+		"declaration": true,
+		"esModuleInterop": true,
+		"skipDefaultLibCheck": true,
+		"skipLibCheck": true
+	},
+	"include": ["lib/front_matter.ts"],
+	"exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true
   },
   "include": [
     "lib/front_matter.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,7 @@
     "sourceMap": true,
     "outDir": "dist",
     "declaration": true,
-    "esModuleInterop": true,
-    "types": [
-      "node"
-    ]
+    "esModuleInterop": true
   },
   "include": [
     "lib/front_matter.ts"


### PR DESCRIPTION
## chore: separate result type and make options as optional
separate result type and make `options` as optional by adding default options an empty object. Prevent assign to undefined variable.

## fix: failed build caused by libs in node_modules
modify `tsconfig.json` to skip typechecking on `node_modules`.

node_modules/@types/hexo/dist/hexo/index.d.ts:4:22 - error TS2307: Cannot find module 'warehouse' or its corresponding type declarations.