### PR TITLE
release: v4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-front-matter",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Front-matter parser.",
   "main": "dist/front_matter",
   "scripts": {


### PR DESCRIPTION
refs: https://github.com/hexojs/hexo/issues/5326

https://github.com/hexojs/hexo/issues/5326 is a blocking issue for the release of hexo `v7.0.0`. We should release a new version of `hexo-front-matter`.