### PR TITLE
fix(ts): missing built-in prototypes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@ tmp/
 .idea/
 coverage
 dist
-package-lock.json
+**/package-lock.json
+**/yarn.lock
+*pnpm-lock.yml
+*pnpm-lock.yaml
+**/.yarn

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hexo-front-matter",
   "version": "4.2.1",
   "description": "Front-matter parser.",
-  "main": "dist/front_matter",
+  "main": "dist/front_matter.js",
   "scripts": {
     "prepublish ": "npm run clean && npm run build",
     "build": "tsc -b",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,8 @@
     "outDir": "dist",
     "declaration": true,
     "esModuleInterop": true,
-    "types": [
-      "node"
-    ]
+    "lib": ["ES2020", "ES6"],
+    "moduleResolution": "Node"
   },
   "include": [
     "lib/front_matter.ts"


### PR DESCRIPTION
fix(ts): missing built-in prototypes

- ignore node lock files
- missing `.js` in main script
- add module lib `ES2020` which already have modern built-in string/number/object/etc prototypes

before add `ES2020`
![44935938-e9929000-ad9c-11e8-8d1b-defccd8c5eae](https://github.com/hexojs/hexo-front-matter/assets/12471057/d6a28d9b-c739-49b9-ab5c-d3f2087f52bf)

after add `ES2020`
![image](https://github.com/hexojs/hexo-front-matter/assets/12471057/f7a7d870-9085-4234-bac5-f62f1e3b3529)

